### PR TITLE
Border bottom and hover effect for lists

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -179,4 +179,13 @@ iframe[seamless] {
 	width: 35%;
 }
 
+/*------------------------------------------------------------------------------
+  2.4 - Common CSS - for all lists
+------------------------------------------------------------------------------*/
+.widefat.fixed td {
+	border-bottom: 1px solid #e1e1e1;
+}
 
+.widefat.fixed tbody tr:hover {
+	background-color: #fff9c0;
+}


### PR DESCRIPTION
A little bit easier to read lists on wide screens.

(Sorry for multiple pull requests. Fourth time like a charm - I hope...)

![lists-widescreen](https://cloud.githubusercontent.com/assets/186420/12378569/2f1737be-bd42-11e5-98da-12bb7484f413.png)
