### PR TITLE
Make sure $action is always an array

### DIFF
--- a/class.config-list-table.php
+++ b/class.config-list-table.php
@@ -33,7 +33,7 @@ class OPcache_List_Table extends WP_List_Table {
 	}
 
 	function column_name($item) {
-		$actions = NULL;
+		$actions = [];
 		if(strpos($item['name'], 'directives.')===0) {
 			$manual = sprintf(
 				'<a href="%1$s/opcache.configuration#ini.%2$s" title="%3$s" target="_blank"><span class="genericon genericon-info"></span></a>',

--- a/class.status-list-table.php
+++ b/class.status-list-table.php
@@ -33,7 +33,7 @@ class OPcache_List_Table extends WP_List_Table {
 	}
 
 	function column_name($item) {
-		$actions = NULL;
+		$actions = [];
 		switch($item['name']) {
 			case 'opcache_enabled':
 				if($item['value']!=='true') $actions['notice'] = __('You should enabled opcache');


### PR DESCRIPTION
On PHP 7.2, an E_WARNING will now be emitted
when attempting to count() non-countable types.